### PR TITLE
Update cart item quantity

### DIFF
--- a/cartSlice.js
+++ b/cartSlice.js
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+export const cartSlice = createSlice({
+  name: 'cart',
+  initialState: {
+    value: []
+  },
+  reducers: {
+    addToCart: (state,action) => {
+ 
+  const findIndex = state.value.findIndex((item )=> item.id == action.payload.id)
+  console.log(findIndex)
+  if(findIndex >= 0){
+    state.value[findIndex].quantity += 1
+  }else{
+    state.value.push({...action.payload,quantity: 1})
+  }
+    
+    },
+
+  }
+})
+
+// Action creators are generated for each case reducer function
+export const { addToCart } = cartSlice.actions
+
+export default cartSlice.reducer


### PR DESCRIPTION
Fixes `quantity` typo in cart slice to correctly increment item quantity and removes unused `increment` export.

---
<a href="https://cursor.com/background-agent?bcId=bc-f46658e6-afbf-4195-9853-f90626a44eb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f46658e6-afbf-4195-9853-f90626a44eb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

